### PR TITLE
binner memory leak fix, metadata improvements

### DIFF
--- a/processor/DldFlashDataframeCreator.py
+++ b/processor/DldFlashDataframeCreator.py
@@ -195,9 +195,9 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
             'electronsPerMacrobunch': self.electronsPerMacrobunch,
         }
         try:
-            self.runInfo['timestampStart'] = self.startEndTime[0].astype(int)
-            self.runInfo['timestampStop'] = self.startEndTime[1].astype(int)
-            self.runInfo['timestampDuration'] = self.startEndTime[1] - self.startEndTime[0].astype(int)
+            self.runInfo['timestampStart'] = int(self.startEndTime[0])
+            self.runInfo['timestampStop'] = int(self.startEndTime[1])
+            self.runInfo['timestampDuration'] = int(self.startEndTime[1] - self.startEndTime[0])
             self.runInfo['timeStart'] = datetime.utcfromtimestamp(self.startEndTime[0]).strftime('%Y-%m-%d %H:%M:%S')
             self.runInfo['timeStop'] = datetime.utcfromtimestamp(self.startEndTime[1]).strftime('%Y-%m-%d %H:%M:%S')
             self.runInfo['timeDuration'] = str(timedelta(seconds=int(self.startEndTime[1] - self.startEndTime[0])))

--- a/processor/DldFlashDataframeCreator.py
+++ b/processor/DldFlashDataframeCreator.py
@@ -809,7 +809,7 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
                                                append=append, ignore_divisions=True)
                 try:
                     with open(os.path.join(fileName + '_el', 'run_metadata.txt'), 'w') as json_file:
-                        json.dump(self.metadata_dict, json_file, indent=4)
+                        json.dump(self.metadata, json_file, indent=4)
                 except AttributeError:
                     print('failed saving metadata')
 

--- a/processor/DldFlashDataframeCreator.py
+++ b/processor/DldFlashDataframeCreator.py
@@ -223,7 +223,7 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
         #     pass
         #
         # print("Number of electrons: {0:,}; {1:,} e/Mb ".format(self.numOfElectrons, self.electronsPerMacrobunch))
-        if bool(self.metadata):
+        if not bool(self.metadata):
             self.metadata = self.get_metadata
 
         print("Creating dataframes... Please wait...")
@@ -810,7 +810,7 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
                 self.ddMicrobunches.to_parquet(fileName + "_mb", compression="UNCOMPRESSED", \
                                                append=append, ignore_divisions=True)
                 try:
-                    if bool(self.metadata):
+                    if not bool(self.metadata):
                         self.metadata = self.get_metadata
                     with open(os.path.join(fileName + '_el', 'run_metadata.txt'), 'w') as json_file:
                         json.dump(self.metadata, json_file, indent=4)

--- a/processor/DldFlashDataframeCreator.py
+++ b/processor/DldFlashDataframeCreator.py
@@ -810,6 +810,8 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
                 self.ddMicrobunches.to_parquet(fileName + "_mb", compression="UNCOMPRESSED", \
                                                append=append, ignore_divisions=True)
                 try:
+                    if self.metadata is None:
+                        self.metadata = self.get_metadata
                     with open(os.path.join(fileName + '_el', 'run_metadata.txt'), 'w') as json_file:
                         json.dump(self.metadata, json_file, indent=4)
                 except AttributeError:

--- a/processor/DldFlashDataframeCreator.py
+++ b/processor/DldFlashDataframeCreator.py
@@ -223,6 +223,8 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
         #     pass
         #
         # print("Number of electrons: {0:,}; {1:,} e/Mb ".format(self.numOfElectrons, self.electronsPerMacrobunch))
+        if self.metadata is None:
+            self.metadata = self.get_metadata
 
         print("Creating dataframes... Please wait...")
         with ProgressBar():

--- a/processor/DldFlashDataframeCreator.py
+++ b/processor/DldFlashDataframeCreator.py
@@ -223,7 +223,7 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
         #     pass
         #
         # print("Number of electrons: {0:,}; {1:,} e/Mb ".format(self.numOfElectrons, self.electronsPerMacrobunch))
-        if self.metadata is None:
+        if bool(self.metadata):
             self.metadata = self.get_metadata
 
         print("Creating dataframes... Please wait...")
@@ -810,7 +810,7 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
                 self.ddMicrobunches.to_parquet(fileName + "_mb", compression="UNCOMPRESSED", \
                                                append=append, ignore_divisions=True)
                 try:
-                    if self.metadata is None:
+                    if bool(self.metadata):
                         self.metadata = self.get_metadata
                     with open(os.path.join(fileName + '_el', 'run_metadata.txt'), 'w') as json_file:
                         json.dump(self.metadata, json_file, indent=4)

--- a/processor/DldFlashDataframeCreator.py
+++ b/processor/DldFlashDataframeCreator.py
@@ -224,7 +224,7 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
         #
         # print("Number of electrons: {0:,}; {1:,} e/Mb ".format(self.numOfElectrons, self.electronsPerMacrobunch))
         if not bool(self.metadata):
-            self.metadata = self.get_metadata
+            self.metadata = self.get_metadata()
 
         print("Creating dataframes... Please wait...")
         with ProgressBar():
@@ -811,7 +811,7 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
                                                append=append, ignore_divisions=True)
                 try:
                     if not bool(self.metadata):
-                        self.metadata = self.get_metadata
+                        self.metadata = self.get_metadata()
                     with open(os.path.join(fileName + '_el', 'run_metadata.txt'), 'w') as json_file:
                         json.dump(self.metadata, json_file, indent=4)
                 except AttributeError:

--- a/processor/DldFlashDataframeCreator.py
+++ b/processor/DldFlashDataframeCreator.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
-from datetime import datetime
+from datetime import datetime,timedelta
 from configparser import ConfigParser
 import dask
 import dask.dataframe
@@ -200,7 +200,7 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
             self.runInfo['timestampDuration'] = self.startEndTime[1] - self.startEndTime[0].astype(int)
             self.runInfo['timeStart'] = datetime.utcfromtimestamp(self.startEndTime[0]).strftime('%Y-%m-%d %H:%M:%S')
             self.runInfo['timeStop'] = datetime.utcfromtimestamp(self.startEndTime[1]).strftime('%Y-%m-%d %H:%M:%S')
-            self.runInfo['timeDuration'] = datetime.timedelta(self.startEndTime[1] - self.startEndTime[0])
+            self.runInfo['timeDuration'] = timedelta(self.startEndTime[1] - self.startEndTime[0])
         except:
             self.runInfo['timestampStart'] = None
             self.runInfo['timestampStop'] = None

--- a/processor/DldFlashDataframeCreator.py
+++ b/processor/DldFlashDataframeCreator.py
@@ -200,7 +200,7 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
             self.runInfo['timestampDuration'] = self.startEndTime[1] - self.startEndTime[0].astype(int)
             self.runInfo['timeStart'] = datetime.utcfromtimestamp(self.startEndTime[0]).strftime('%Y-%m-%d %H:%M:%S')
             self.runInfo['timeStop'] = datetime.utcfromtimestamp(self.startEndTime[1]).strftime('%Y-%m-%d %H:%M:%S')
-            self.runInfo['timeDuration'] = timedelta(self.startEndTime[1] - self.startEndTime[0])
+            self.runInfo['timeDuration'] = str(timedelta(seconds=int(self.startEndTime[1] - self.startEndTime[0])))
         except:
             self.runInfo['timestampStart'] = None
             self.runInfo['timestampStop'] = None

--- a/processor/DldProcessor.py
+++ b/processor/DldProcessor.py
@@ -417,23 +417,23 @@ class DldProcessor:
         except AttributeError:
             pass
         try:
-            i = self.metadata_dict['run']
+            i = self.metadata_dict
         except:
             pass                
             
         if i is None:
             print('no run info available.')
         else:
-            print(f'Run {i["runNumber"]}')
+            print(f'Run {i['run']['runNumber']}')
             try:
-                print(f"Started at {i['timeStart']}, finished at {i['timeStop']}, "
-                      f"total duration {i['timeDuration']:,} s")
+                print(f"Started at {i['timing']['acquisition start']}, finished at {i['timing']['acquisition stop']}, "
+                      f"total duration {i['timing']['acquisition duration']:,} s")
             except:
                 pass
-            print(f"Macrobunches: {i['numberOfMacrobunches']:,}  "
-                  f"from {i['pulseIdInterval'][0]:,} to {i['pulseIdInterval'][1]:,} ")
-            print(f"Total electrons: {i['numberOfElectrons']:,}, "
-                  f"electrons/Macrobunch {i['electronsPerMacrobunch']:}")
+            print(f"Macrobunches: {i['run']['numberOfMacrobunches']:,}  "
+                  f"from {i['run']['macroBunchPulseIdInterval'][0]:,} to {i['run']['macroBunchPulseIdInterval'][1]:,} ")
+            print(f"Total electrons: {i['run']['nElectrons']:,}, "
+                  f"electrons/Macrobunch {i['run']['electronsPerMacrobunch']:}")
 
     # ==========================
     # Dataframe column expansion
@@ -1355,7 +1355,7 @@ class DldProcessor:
                               # 'bin array creation': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
                               }
         metadata['sample'] = self.sample
-        metadata['settings'] = dict(self.settings._sections['DAQ channels'])#misc.parse_category('processor')
+        metadata['settings'] = dict(self.settings._sections['processor'])#misc.parse_category('processor')
         metadata['DAQ channels'] = dict(self.settings._sections['DAQ channels'])#misc.parse_category('DAQ channels')
         if self.pulseIdInterval is None and not fast_mode:
             pulseIdFrom = self.dd['macroBunchPulseId'].min().compute()

--- a/processor/DldProcessor.py
+++ b/processor/DldProcessor.py
@@ -87,11 +87,11 @@ class DldProcessor:
     @property
     def metadata_dict(self):
 
-        try:
-            md = self.metadata
-        except AttributeError:
+        if self.metadata is None:
             md = self.get_metadata()
             self.metadata = md
+        else:
+            md = self.metadata
         return md
 
     @property
@@ -391,7 +391,7 @@ class DldProcessor:
         except AttributeError:
             pass
         try:
-            i = self.metadata_dict['runInfo']
+            i = self.metadata['runInfo']
         except:
             pass                
             

--- a/processor/DldProcessor.py
+++ b/processor/DldProcessor.py
@@ -1292,19 +1292,24 @@ class DldProcessor:
                     #                print("computing partitions " + str(i) + " to " + str(i + j) + " of " + str(
                     #                    self.dd.npartitions) + ". partitions calculated in parallel: " + str(
                     #                    len(resultsToCalculate)))
-                    results = dask.compute(*resultsToCalculate)
-                    total = np.zeros_like(results[0])
-                    for result in results:
-                        total = total + result
-                    calculatedResults.append(total)
-                    del total
+                    rs = dask.compute(*resultsToCalculate)
+                    try:
+                        result
+                        for r in rs:
+                            result = result + r
+                    except NameError:
+                        result = np.zeros_like(rs[0])
+                        for r in rs:
+                            result = result + r
+
+                    del rs
                 del resultsToCalculate
 
         # we now need to add them all up (single core):
-        result = np.zeros_like(calculatedResults[0])
-        for r in calculatedResults:
-            r = np.nan_to_num(r)
-            result = result + r
+        # result = np.zeros_like(calculatedResults[0])
+        # for r in calculatedResults:
+        #     r = np.nan_to_num(r)
+        #     result = result + r
 
         if force_64bit:
             result = result.astype(np.float64)

--- a/processor/DldProcessor.py
+++ b/processor/DldProcessor.py
@@ -398,7 +398,7 @@ class DldProcessor:
         if i is None:
             print('no run info available.')
         else:
-            print(f'Run {i['runNumber']}')
+            print(f"Run {i['runNumber']}")
             try:
                 print(f"Started at {i['timestampStart']}, finished at {i['timestampStop']}, "
                       f"total duration {i['timestampDuration']:,} s")

--- a/processor/DldProcessor.py
+++ b/processor/DldProcessor.py
@@ -1351,12 +1351,12 @@ class DldProcessor:
 
         metadata['timing'] = {'acquisition start': datetime.fromtimestamp(start).strftime('%Y-%m-%d %H:%M:%S'),
                               'acquisition stop': datetime.fromtimestamp(stop).strftime('%Y-%m-%d %H:%M:%S'),
-                              'acquisition duration': np.int32(stop - start),
+                              'acquisition duration': int(stop - start),
                               # 'bin array creation': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
                               }
         metadata['sample'] = self.sample
-        metadata['settings'] = self.settings['processor']#misc.parse_category('processor')
-        metadata['DAQ channels'] = self.settings['DAQ channels']#misc.parse_category('DAQ channels')
+        metadata['settings'] = dict(self.settings._sections['DAQ channels'])#misc.parse_category('processor')
+        metadata['DAQ channels'] = dict(self.settings._sections['DAQ channels'])#misc.parse_category('DAQ channels')
         if self.pulseIdInterval is None and not fast_mode:
             pulseIdFrom = self.dd['macroBunchPulseId'].min().compute()
             pulseIdTo = self.dd['macroBunchPulseId'].max().compute()

--- a/processor/DldProcessor.py
+++ b/processor/DldProcessor.py
@@ -1293,6 +1293,7 @@ class DldProcessor:
                     #                    self.dd.npartitions) + ". partitions calculated in parallel: " + str(
                     #                    len(resultsToCalculate)))
                     rs = dask.compute(*resultsToCalculate)
+                    # we now need to add them all up (single core):
                     try:
                         result
                         for r in rs:
@@ -1304,12 +1305,6 @@ class DldProcessor:
 
                     del rs
                 del resultsToCalculate
-
-        # we now need to add them all up (single core):
-        # result = np.zeros_like(calculatedResults[0])
-        # for r in calculatedResults:
-        #     r = np.nan_to_num(r)
-        #     result = result + r
 
         if force_64bit:
             result = result.astype(np.float64)
@@ -1356,7 +1351,7 @@ class DldProcessor:
 
         metadata['timing'] = {'acquisition start': datetime.fromtimestamp(start).strftime('%Y-%m-%d %H:%M:%S'),
                               'acquisition stop': datetime.fromtimestamp(stop).strftime('%Y-%m-%d %H:%M:%S'),
-                              'acquisition duration': stop - start,
+                              'acquisition duration': np.int32(stop - start),
                               # 'bin array creation': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
                               }
         metadata['sample'] = self.sample


### PR DESCRIPTION
- Fixes a memory leak in the binner, where you needed n_cpu+n_partitions/n_cpu times the destination array size in memory. Now you need 1+n_cpu.

- Harmonized metadata creation and generates it automatically when needed. Requires new parquet files to benefit fully from this