### PR TITLE
add function to correct for dld misalignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ data_results_dir = /asap3/flash/gpfs/pg2/YYYY/data/xxxxxxxx/processed/*USER_NAME
 ```
 Where `YYYY` is the current year and `xxxxxxxx` is the beamtime number.
 
+### 3.5 Calculating sector_correction list
+If you like, in the settings, you can add the sector_correction list, which will shift any misalignment of the sectors.
+At the very least, this should include the "bit stealing hack" correction, where the last bits of the dldTime
+are set so they encode dldSectorId. This can be achieved by using the calibration.gen_sector_correction function
+which will generate the list for you, given the energy shifts you want.
+
 ### 4. Further requirements
 Here is a list of packages which need to be installed in order to use all the features available in this package.
 
@@ -178,21 +184,21 @@ XPSdoniachs_ext.dsgn
 XPSdoniachs_ext.dsgnmEad2
 XPSdoniachs_ext.dsgnmBad2
 ```
-- The first one, dsgn, is a single DS function convoluted with a gaussian with a linear background. It has 7 parameters:
-w[0] is the bg offset
-w[1] is the bg slope
+The first one, dsgn, is a single DS function convoluted with a gaussian with a linear background. It has 7 parameters:
+- w[0] is the bg offset
+- w[1] is the bg slope
 
-w[2] L - first lineshape parameter, this is the Lorentzian FWHM
-w[3] A - second lineshape parameter, this is the asymmetry parameter
-w[4] G - third lineshape parameter, this is the Gaussian FWHM
+- w[2] L - first lineshape parameter, this is the Lorentzian FWHM
+- w[3] A - second lineshape parameter, this is the asymmetry parameter
+- w[4] G - third lineshape parameter, this is the Gaussian FWHM
 
-w[5] this is the intensity
-w[6] this is the binding energy, with asymmetry towards the left, fermi edge on the right
+- w[5] this is the intensity
+- w[6] this is the binding energy, with asymmetry towards the left, fermi edge on the right
 
-- The second one, dsgnmEad2, is a multiple DS function. It is the same as dsgn, but ou can include multiple peaks
+The second one, dsgnmEad2, is a multiple DS function. It is the same as dsgn, but ou can include multiple peaks
 by adding 5 additional parameters per peak after w[6]. The binding energy is relative to the first peak.
 
-- The third one, dsgnmBad2, is a multiple DS function. It is the same as dsgn, but ou can include multiple peaks
+The third one, dsgnmBad2, is a multiple DS function. It is the same as dsgn, but ou can include multiple peaks
 by adding 5 additional parameters per peak after w[6]. The binding energy is absolute.
 
 ### XPSdoniachs Usage

--- a/processor/DldFlashDataframeCreator.py
+++ b/processor/DldFlashDataframeCreator.py
@@ -161,13 +161,15 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
             for address_name in self.daqAddresses:
                 if _VERBOSE:
                     print('reading address: {}'.format(address_name))
-                setattr(self, address_name, daqAccess.valuesOfInterval(getattr(self, address_name), pulseIdInterval))
+                values = daqAccess.valuesOfInterval(getattr(self, address_name), pulseIdInterval)
+                setattr(self, address_name, values)
+                if address_name == 'timeStamp':  # catch the time stamps
+                    startEndTime = (values[0, 0], values[-1, 0])
+                    self.startEndTime = startEndTime
             numOfMacrobunches = pulseIdInterval[1] - pulseIdInterval[0]
             macroBunchPulseId_correction = pulseIdInterval[0]
 
-            if address_name == 'timeStamp':  # catch the time stamps
-                startEndTime = (values[0, 0], values[-1, 0])
-                self.startEndTime = startEndTime
+
 
 
         # necessary corrections for specific channels:

--- a/processor/DldFlashDataframeCreator.py
+++ b/processor/DldFlashDataframeCreator.py
@@ -165,6 +165,11 @@ class DldFlashProcessor(DldProcessor.DldProcessor):
             numOfMacrobunches = pulseIdInterval[1] - pulseIdInterval[0]
             macroBunchPulseId_correction = pulseIdInterval[0]
 
+            if address_name == 'timeStamp':  # catch the time stamps
+                startEndTime = (values[0, 0], values[-1, 0])
+                self.startEndTime = startEndTime
+
+
         # necessary corrections for specific channels:
         try:
             self.delayStage = self.delayStage[:, 1]

--- a/processor/utilities/calibration.py
+++ b/processor/utilities/calibration.py
@@ -14,6 +14,9 @@ def gen_sector_correction(prc, energies, eref, tofVoltage=None, sampleBias=None,
     plus is keeps track of the time shift due to detector misalignment by making sure
     all values of energies are at eref.
 
+    Usage: use the function to create the sector_correction list and assign it to prc.SECTOR_CORRECTION
+    or paste it into the settings with no brackets
+
     :param prc:
     :param energies:
     :param eref:
@@ -27,8 +30,13 @@ def gen_sector_correction(prc, energies, eref, tofVoltage=None, sampleBias=None,
     if tofVoltage is None:
         tofVoltage = np.nanmean(prc.dd['tofVoltage'].values)
 
+    # Here, the most basic sector_correction list is generated, where the bit stealing hack gets corrected
     n_sectors=prc.dd['dldSectorId'].values.compute().max().astype(int)+1
     sector_correction = np.floor(np.array(range(n_sectors))*np.power(2,prc.DLD_ID_BITS)/n_sectors)
+    # e.g. for 3 stolen bits, 8 detector ids (new s8 data), this will look like [0,1,2,3,4,5,6,7]
+    # e.g. for 1 stolen bit, 8 detector ids (old modified s8 data), this will look like [0,0,0,0,1,1,1,1]
+    # e.g. for 1 stolen bit, 2 detector ids (old s8 data), this will look like [0,1]
+
 
     t_ref = energy2tof(eref, l=0.965, eoffset=-2.64-sampleBias+tofVoltage+monoEnergy)
 
@@ -37,6 +45,7 @@ def gen_sector_correction(prc, energies, eref, tofVoltage=None, sampleBias=None,
         times.append((energy2tof(ee, l=0.965, eoffset=-2.64-47+30+monoEnergy)-t_ref)/prc.TOF_STEP_TO_NS)
 
     sector_correction=sector_correction+np.array(times)
+    # here the sectors are shifter by the required time to align the energies
 
     return sector_correction
 

--- a/settings/Curcio_2017.ini
+++ b/settings/Curcio_2017.ini
@@ -17,7 +17,7 @@ return_xarray = True
 single_core_dataframe_creation = True
 use_streak = False
 use_bam = False
-sector_correction = 0,1
+sector_correction = 10.89021245,  17.04709533, -13.82056132, -18.81060718, 16.16265069,  17.23678399,   8.08076724,   7.38013127
 dld_id_bits = 1
 
 [DAQ channels]


### PR DESCRIPTION
this is supposed to fix #46, by introducing a method that generates the SECTOR_CORRECTION list. This can be pasted in the settings file, with the aim of aligning the dldTime of the different sectors, in order to increase the energy resolution.