### PR TITLE
Seperating config for data preprocessing and adding an abstraction layer

### DIFF
--- a/src/processor/DataframeCreator.py
+++ b/src/processor/DataframeCreator.py
@@ -1,0 +1,57 @@
+import os
+from pathlib import Path
+import yaml
+from processor.DldFlashDataframeCreatorExpress import DldFlashProcessorExpress
+from processor.LabDataframeCreator import LabDataframeCreator
+
+class DataframeCreator():
+    def __init__(self, config, filenames = None, runNumber = None, settings = None):
+        self.config_parser(config)
+        if self.acquisition == 'flash':
+            self.prc = DldFlashProcessorExpress(self, runNumber, settings)
+        if self.acquisition == 'lab':
+            self.prc = LabDataframeCreator(self, filenames, settings)
+
+    def config_parser(self, config):
+        with open(config) as file:
+            config = yaml.load_all(file, Loader=yaml.FullLoader)
+            for doc in config:
+                if 'general' in doc.keys():
+                    self.general = doc['general']
+                if 'channels' in doc.keys():
+                    self.channels = doc['channels']
+                if 'paths' in doc.keys():
+                    self.paths = doc['paths']
+
+            if not {'acquisition', 'ubid_offset', 'daq'}.issubset(self.general.keys()):
+                    raise ValueError('One of the values from acquisition, ubid_offset or daq is missing. These are necessary.')
+            self.acquisition = self.general['acquisition']
+            self.UBID_OFFSET = self.general['ubid_offset']
+            self.DAQ = self.general['daq']
+
+            # Prases to locate the raw beamtime directory from config file
+            if self.paths:
+                if 'data_raw_dir' in self.paths:
+                    self.DATA_RAW_DIR = Path(self.paths['data_raw_dir'])
+                if 'data_parquet_dir' in self.paths:
+                    self.DATA_PARQUET_DIR = Path(self.paths['data_parquet_dir'])
+            else:
+                if {'beamtime_id', 'year'}.issubset(self.general.keys()):
+                    raise ValueError('The beamtime_id and year or data_raw_dir is required.')
+
+                beamtime_id = self.general['beamtime_id']
+                year = self.general['year']
+                beamtime_dir = Path(f'/asap3/flash/gpfs/pg2/{year}/data/{beamtime_id}/')
+
+                # Folder naming convention till end of October
+                self.DATA_RAW_DIR = beamtime_dir.joinpath('raw/hdf/express')
+                # Use new convention if express doesn't exist
+                if not self.DATA_RAW_DIR.exists():
+                    self.DATA_RAW_DIR = beamtime_dir.joinpath(f'raw/hdf/{self.DAQ.upper()}')
+
+                if self.DATA_PARQUET_DIR is None:
+                    parquet_path = 'processed/parquet'
+                    self.DATA_PARQUET_DIR = beamtime_dir.joinpath(parquet_path)
+
+                if not self.DATA_PARQUET_DIR.exists():
+                    os.mkdir(self.DATA_PARQUET_DIR)

--- a/src/processor/DldFlashDataframeCreatorExpress.py
+++ b/src/processor/DldFlashDataframeCreatorExpress.py
@@ -1,18 +1,14 @@
-from processor.DldProcessor import DldProcessor
-import sys, os
-import glob
+import os
 import json
 import h5py
 import numpy as np
 from pandas import Series, DataFrame, concat, MultiIndex
-from dask import delayed, compute
 import dask.dataframe as dd
-from dask.diagnostics import ProgressBar
 from pathlib import Path
 from functools import reduce
-from configparser import ConfigParser
 from multiprocessing import Pool, cpu_count
 from itertools import compress
+from processor.DldProcessor import DldProcessor
 
 """
     author:: Muhammad Zain Sohail, Steinn Ymir Agustsson

--- a/src/processor/LabDataframeCreator.py
+++ b/src/processor/LabDataframeCreator.py
@@ -1,19 +1,14 @@
-from processor.DldProcessor import DldProcessor
-from processor.utilities import misc
-import sys, os
-import glob
+import os
 import json
 import h5py
 import numpy as np
-from pandas import Series, DataFrame, concat, MultiIndex, read_parquet
-from dask import delayed, compute
+from pandas import Series, DataFrame, concat
 import dask.dataframe as dd
-from dask.diagnostics import ProgressBar
 from pathlib import Path
 from functools import reduce
-from configparser import ConfigParser
 from multiprocessing import Pool, cpu_count
-from itertools import compress
+from processor.DldProcessor import DldProcessor
+from processor.utilities import misc
 
 """
     author:: Muhammad Zain Sohail, Steinn Ymir Agustsson

--- a/src/processor/LabDataframeCreator.py
+++ b/src/processor/LabDataframeCreator.py
@@ -22,23 +22,13 @@ class LabDataframeCreator(DldProcessor):
     The class generates multidimensional pandas dataframes 
     from the lab data resolved by both macro and microbunches alongside electrons.
     """
-    def __init__(self, path = None, filenames = None, channels = None, settings = None, silent=False):
+    def __init__(self, prc, filenames = None, settings = None, silent=False):
         
         super().__init__(settings=settings,silent=silent)
         self.filenames = filenames
-        self.path = path
-        
-        # Parses and stores the channel names that are defined by the json file
-        if channels is None:
-            all_channel_list_dir = os.path.join(Path(__file__).parent.absolute(), "channels_lab.json")
-        else:
-            all_channel_list_dir = channels
-        # Read all channel info from a json file
-        if isinstance(all_channel_list_dir,dict):
-            self.all_channels = channels
-        else:
-            with open(all_channel_list_dir, "r") as json_file:
-                self.all_channels = json.load(json_file)
+        self.path = prc.DATA_RAW_DIR
+        self.parquet_dir = prc.DATA_PARQUET_DIR
+        self.all_channels = prc.channels
         self.channels = self.availableChannels
         
     @property
@@ -137,14 +127,6 @@ class LabDataframeCreator(DldProcessor):
             raise ValueError('Must provide a path!')
         else:
             self.path = Path(path)
-        
-        # create a per_file directory
-        if parquet_path is None:
-            self.parquet_dir = self.path.joinpath('parquet')
-        else:
-            self.parquet_dir = Path(parquet_path)
-        if not self.parquet_dir.exists():
-            os.mkdir(self.parquet_dir)
         
         # prepare a list of names for the files to read and parquets to write
         try: 

--- a/tutorial/Tutorial_01_Binning calibrating and saving data.ipynb
+++ b/tutorial/Tutorial_01_Binning calibrating and saving data.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,8 +44,8 @@
     "%matplotlib notebook \n",
     "\n",
     "# hextof-processor imports\n",
-    "sys.path.append(os.path.dirname(os.getcwd()) ) # add hextof-processor to path\n",
-    "from processor.DldFlashDataframeCreatorExpress import DldFlashProcessorExpress, DldProcessor\n",
+    "sys.path.append(os.path.dirname(os.getcwd()) + '/src/') # add hextof-processor to path\n",
+    "from processor.DataframeCreator import DataframeCreator\n",
     "from processor.utilities import calibration, diagnostics, misc, io, vis"
    ]
   },
@@ -58,19 +58,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using settings from tutorial.ini\n"
+     ]
+    },
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: '/asap3/flash/gpfs/pg2/2020/data/11008860/processed/parquet/per_file'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-4-7d10d2c290e2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mprc\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mDataframeCreator\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'config.yml'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrunNumber\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m22097\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msettings\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'tutorial'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m \u001b[0mprc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreadData\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;31m# read the raw data and generate the single event tables\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      6\u001b[0m \u001b[0;31m# prc.storeDataframes() # store the single event tables as parquet files.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/hextof-processor/src/processor/DldFlashDataframeCreatorExpress.py\u001b[0m in \u001b[0;36mreadData\u001b[0;34m(self, runs, ignore_missing_runs, settings, channels, beamtime_dir, parquet_path, beamtime_id, year, daq)\u001b[0m\n\u001b[1;32m    348\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtemp_parquet_dir\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDATA_PARQUET_DIR\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjoinpath\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'per_file'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    349\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtemp_parquet_dir\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexists\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 350\u001b[0;31m             \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmkdir\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtemp_parquet_dir\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    351\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    352\u001b[0m         \u001b[0;31m# Prepare a list of names for the files to read and parquets to write\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '/asap3/flash/gpfs/pg2/2020/data/11008860/processed/parquet/per_file'"
+     ]
+    }
+   ],
    "source": [
     "# load the correct configuration for the dataset you want to read.\n",
     "# This can be different for each beamtime.\n",
-    "prc = DldFlashProcessorExpress(settings = 'tutorial')\n",
-    "prc.DATA_RAW_DIR = '../tutorial/raw' # manually overwrite data folder to use the tutorial dataset\n",
-    "prc.DATA_PARQUET_DIR = '../tutorial/parquet' # manually overwrite parquet data folder. it is STRONGLY recomendend to use an SSD drive here.\n",
-    "prc.runNumber = 22097 # run number of the example data given for this tutorial\n",
-    "prc.readData() # read the raw data and generate the single event tables\n",
-    "prc.storeDataframes() # store the single event tables as parquet files.    \n",
+    "prc = DataframeCreator('config.yml', runNumber=22097, settings = 'tutorial')\n",
+    "\n",
+    "prc.prc.readData() # read the raw data and generate the single event tables\n",
+    "# prc.storeDataframes() # store the single event tables as parquet files.    \n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DldFlashProcessor.\n",
+       "- Run Number: 22097\n",
+       "- MacrobunchIds: [None, None]\n",
+       "- Settings loaded from /home/zains/hextof-processor/settings/tutorial.ini\n",
+       "- Bins:"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prc.prc"
    ]
   },
   {
@@ -340,10 +382,13 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "49cf1b99b458a759a3d83c7dee9b6494dee31bdc0508aa200a4853f37a5874ba"
+  },
   "kernelspec": {
    "display_name": "hextof-express",
    "language": "python",
-   "name": "hextof-express"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -355,7 +400,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/tutorial/config.yml
+++ b/tutorial/config.yml
@@ -1,0 +1,72 @@
+---
+general:
+  acquisition: flash
+  beamtime_id: 11008860
+  year: 2020
+  ubid_offset: 5
+  daq: fl1user2
+---
+channels:
+  pulseId:
+    axis: 1
+    format: per_electron
+    group_name: "/FL1/Experiment/PG/Hextof/Detector/monitor/"
+    slice: 2
+  bam:
+    format: per_pulse
+    group_name: "/FL1/Electron Diagnostic/BAM/4DBC3/electron bunch arrival time (low charge)/"
+    slice: ":"
+  delayStage:
+    format: per_train
+    group_name: "/uncategorised/FLASH.SYNC/LASER.LOCK.EXP/FLASH1.MOD1.PG.OSC/FMC0.MD22.1.POSITION.RD/"
+    slice: ":"
+  dldAux:
+    format: per_pulse
+    group_name: "/FL1/Experiment/PG/Hextof/Detector/monitor/"
+    slice: 4
+    axis: 1
+    dldAuxChannels:
+      sampleBias: 0
+      tofVoltage: 1
+      extractorVoltage: 2
+      extractorCurrent: 3
+      cryoTemperature: 4
+      sampleTemperature: 5
+      dldTimeBinSize: 15
+  dldPosX:
+    axis: 1
+    format: per_electron
+    group_name: "/FL1/Experiment/PG/Hextof/Detector/monitor/"
+    slice: 1
+  dldPosY:
+    axis: 1
+    format: per_electron
+    group_name: "/FL1/Experiment/PG/Hextof/Detector/monitor/"
+    slice: 0
+  dldTime:
+    axis: 1
+    format: per_electron
+    group_name: "/FL1/Experiment/PG/Hextof/Detector/monitor/"
+    slice: 3
+  gmdBda:
+    axis: 1
+    format: per_pulse
+    group_name: "/FL1/Photon Diagnostic/GMD/Pulse resolved energy/energy BDA/"
+    slice: 0
+  gmdTunnel:
+    axis: 1
+    format: per_pulse
+    group_name: "/FL1/Photon Diagnostic/GMD/Pulse resolved energy/energy tunnel/"
+    slice: 0
+  monochromatorPhotonEnergy:
+    format: per_train
+    group_name: "/FL1/Beamlines/PG/Monochromator/monochromator photon energy/"
+    slice: ":"
+  timeStamp:
+    format: per_train
+    group_name: "/FL1/Timing/Bunch pattern/train index 1/"
+    slice: ":"
+---
+paths:
+  data_raw_dir: /asap3/flash/gpfs/pg2/2020/data/11008860/raw/hdf/express/
+  data_parquet_dir: /asap3/flash/gpfs/pg2/2020/data/11008860/processed/parquet/


### PR DESCRIPTION
- I have now introduced a new config file which includes everything necessary for preprocessing the data to the parquet file.
- In this file, it is also defined whether the data was acquired at flash or lab. 
- New class DataframeCreator abstracts the DldFlashDataframeCreatorExpress and LabDataframeCreator from the user.

This probably still doesn't work but I wanted to get suggestions already on what you think of this idea.